### PR TITLE
nile-common- Remove priv-app whitelist

### DIFF
--- a/vendor_prop.mk
+++ b/vendor_prop.mk
@@ -114,10 +114,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.extension_library=libqti-perfd-client.so
 
-# Priv-app permissions whitelist
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.control_privapp_permissions=enforce
-
 # Radio
 PRODUCT_PROPERTY_OVERRIDES += \
     DEVICE_PROVISIONED=1 \


### PR DESCRIPTION
due to this users are very limited to what apps they can and cant use and if they flash anything that is not in that white list it causes a bootloop. This is causing bootloops with the higher package gapps because NOT all the apks are within the whitelist.